### PR TITLE
Add a test case for join operation

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -264,3 +264,26 @@ def test_join_success():
             [M, 60],
         ],
     )
+
+    # 8. mat 2 has multiple matches for a mat 1 key
+    execute_join_test(
+        mpcstats_lib.join,
+        [
+            [
+                [0, 1],
+                [10, 20],
+            ],
+            [
+                [3, 1, 9, 1],
+                [50, 60, 70, 80],
+            ],
+        ],
+        0,
+        0,
+        [
+            [0, 1],
+            [10, 20],
+            [M, 1],
+            [M, 80],
+        ],
+    )


### PR DESCRIPTION
- Add a test case for join operation to cover the case where a multiple instances of a base table key is included in the target table key column