### PR TITLE
Add variance and linear_regression functions

### DIFF
--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -260,11 +260,11 @@ def harmonic_mean(data: list[sint]):
     eff_inv_mean = eff_inv_total / eff_size
     result = 1 / eff_inv_mean
 
-    # statistics.harmonic_mean retuns zero if data contain zero
-    zero_found = 0
+    # statistics.harmonic_mean returns zero if data contain zero
+    num_zeros = 0
     for x in data:
-        zero_found += (x == 0)
-    result = 0 * (zero_found > 0) + result * (zero_found == 0)
+        num_zeros += (x == 0)
+    result *= (num_zeros == 0)
 
     return result
 

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -258,7 +258,15 @@ def harmonic_mean(data: list[sint]):
     eff_size = sum(if_else(n != MAGIC_NUMBER, 1, 0) for n in data)
     eff_inv_total = sum(if_else(n != MAGIC_NUMBER, 1/n, 0) for n in data)
     eff_inv_mean = eff_inv_total / eff_size
-    return 1 / eff_inv_mean
+    result = 1 / eff_inv_mean
+
+    # statistics.harmonic_mean retuns zero if data contain zero
+    zero_found = 0
+    for x in data:
+        zero_found += (x == 0)
+    result = 0 * (zero_found > 0) + result * (zero_found == 0)
+
+    return result
 
 
 def pvariance(data: list[sint]):

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -19,11 +19,11 @@ def read_data(party_index: int, num_columns: int, num_rows: int) -> Matrix:
     """
     Read data from each party's input file to a Matrix in MP-SPDZ circuit.
     """
-    data = Matrix(num_columns, num_rows, sint)
+    data = Matrix(num_columns, num_rows, sfix)
     # TODO: use @for_range_opt instead?
     for i in range(num_columns):
         for j in range(num_rows):
-            data[i][j] = sint.get_input_from(party_index)
+            data[i][j] = sfix.get_input_from(party_index)
     return data
 
 
@@ -38,20 +38,20 @@ def print_data(data: Matrix):
             print_ln("data[{}][{}]: %s".format(i, j), data[i][j].reveal())
 
 
-def _mean(data: list[sint]) -> (float, int):
-    total = sum(if_else(i != MAGIC_NUMBER, i, 0) for i in data)
-    count = sum(if_else(i != MAGIC_NUMBER, 1, 0) for i in data)
+def _mean(data: list[sfix]) -> (sfix, sfix):
+    total = sfix(sum(if_else(i != MAGIC_NUMBER, i, 0) for i in data))
+    count = sfix(sum(if_else(i != MAGIC_NUMBER, 1, 0) for i in data))
     return total / count, count
 
 
-def _variance(data: list[sint], use_bessels: bool) -> float:
+def _variance(data: list[sfix], use_bessels: bool) -> sfix:
     # calculate mean of the data excluding magic numbers
     mean, eff_size = _mean(data)
 
     # replace magic number w/ mean to skip magic number in for loop below
     data = Array.create_from(if_else(n != MAGIC_NUMBER, n, mean) for n in data)
 
-    eff_data_sum = sfloat(0)
+    eff_data_sum = sfix(0)
     for n in data:
         eff_data_sum += (n - mean) ** 2
 
@@ -63,27 +63,27 @@ def _variance(data: list[sint], use_bessels: bool) -> float:
 
 # Top 5 functions to implement
 
-def mean(data: list[sint]):
+def mean(data: list[sfix]) -> sfix:
     return _mean(data)[0]
 
 
-def median(data: list[sint]):
+def median(data: list[sfix]):
     # TODO: Check if Array.create_from is properly constrained // if I dont put reference, it's just from the mp-spdz doc itself
     data = Array.create_from(data)
-    # TODO: Check if there's a need to use sint(0), can we just use 0? would that violate constraint?
-    median_odd = sint(0)
-    median_even = sint(0)
+    # TODO: Check if there's a need to use sfix(0), can we just use 0? would that violate constraint?
+    median_odd = sfix(0)
+    median_even = sfix(0)
     data.sort()
     size = sum(if_else(i!= MAGIC_NUMBER, 1, 0) for i in data)
 
     # TODO: Check if for_range is any different than naive Python for-loop
     @for_range(len(data))
     def _(i):
-        # TODO: Check if wrapping sint() makes sense/ properly constrained
+        # TODO: Check if wrapping sfix() makes sense/ properly constrained
         # TODO: Check why we cannot just use size.int_div(2) -> it returns wrong result, so now we use the method below instead.
-        median_odd.update(median_odd+(size==2*sint(i)+size%2)*data[i])
+        median_odd.update(median_odd+(size==2*sfix(i)+size%2)*data[i])
         # TODO: Check if there's the need to use update: See example in Compiler.library.for_range(start, stop=None, step=None) in the mp-spdz doc itself
-        median_even.update(median_even+(size==2*sint(i)+size%2)*data[i]/2+(size-2==2*sint(i)+size%2)*data[i]/2)
+        median_even.update(median_even+(size==2*sfix(i)+size%2)*data[i]/2+(size-2==2*sfix(i)+size%2)*data[i]/2)
     # TODO: Check if size%2 is properly constrained
     return (size%2)*median_odd + (1-size%2)*median_even
 
@@ -118,7 +118,7 @@ def join(data1: Matrix, data2: Matrix, data1_column_index: int, data2_column_ind
     num_columns_2 = data2.shape[0]
     num_rows_2 = data2.shape[1]
 
-    new_data = Matrix(num_columns_1 + num_columns_2, num_rows_1, sint)
+    new_data = Matrix(num_columns_1 + num_columns_2, num_rows_1, sfix)
     # Initialize the first part of the matrix with data1
     for i in range(num_columns_1):
         for j in range(num_rows_1):
@@ -146,29 +146,29 @@ def join(data1: Matrix, data2: Matrix, data1_column_index: int, data2_column_ind
     return new_data
 
 
-def covariance(data1: list[sint], data2: list[sint]):
+def covariance(data1: list[sfix], data2: list[sfix]):
     n = len(data1)
     mean1, count = _mean(data1)
     mean2, _ = _mean(data2)
     data1 = Array.create_from(if_else(i!=MAGIC_NUMBER, i, mean1) for i in data1)
     data2 = Array.create_from(if_else(i!=MAGIC_NUMBER, i, mean2) for i in data2)
     # TODO: Check if there's a need to use sfloat(0), can we do something like 0.0
-    x = sfloat(0)
+    x = sfix(0)
     @for_range(n)
     def _(i):
         x.update(x+(data1[i]-mean1)*(data2[i]-mean2))
     return x/(count-1)
 
 
-def correlation(data1: list[sint], data2: list[sint]):
+def correlation(data1: list[sfix], data2: list[sfix]):
     n = len(data1)
     mean1, count = _mean(data1)
     mean2, _ = _mean(data2)
     data1 = Array.create_from(if_else(i!=MAGIC_NUMBER, i, mean1) for i in data1)
     data2 = Array.create_from(if_else(i!=MAGIC_NUMBER, i, mean2) for i in data2)
-    numerator = sfloat(0)
-    denominator1 = sfloat(0)
-    denominator2 = sfloat(0)
+    numerator = sfix(0)
+    denominator1 = sfix(0)
+    denominator2 = sfix(0)
     @for_range(n)
     def _(i):
         numerator.update(numerator+(data1[i]-mean1)*(data2[i]-mean2))
@@ -178,29 +178,29 @@ def correlation(data1: list[sint], data2: list[sint]):
     return numerator/(sqrt(sfix(denominator1))*sqrt(sfix(denominator2)))
 
 
-def where(_filter: list[sint], data: list[sint]):
+def where(_filter: list[sfix], data: list[sfix]):
     n = len(data)
     data = Array.create_from(data)
     _filter = Array.create_from(_filter)
-    res = sint.Array(n)
+    res = sfix.Array(n)
     @for_range(n)
     def _(i):
         res[i] = if_else(_filter[i], data[i], MAGIC_NUMBER)
     return res
 
 
-def geometric_mean(data: list[sint]):
-    log_sum = sum(if_else(i != MAGIC_NUMBER, log2_fx(i), 0) for i in data)
-    num_log_sums = sum(if_else(i != MAGIC_NUMBER, 1, 0) for i in data)
+def geometric_mean(data: list[sfix]):
+    log_sum = sfix(sum(if_else(i != MAGIC_NUMBER, log2_fx(i), 0) for i in data))
+    num_log_sums = sfix(sum(if_else(i != MAGIC_NUMBER, 1, 0) for i in data))
     exponent = log_sum / num_log_sums
 
     return exp2_fx(exponent)
 
 
-def mode(data: list[sint]):
+def mode(data: list[sfix]):
     n = len(data)
     data = Array.create_from(data)
-    freqs = sint.Array(n)
+    freqs = sint.Array(n) # sfix doesn't support greater_than
 
     # find frequency of each element in data
     for i, x in enumerate(data):
@@ -208,7 +208,7 @@ def mode(data: list[sint]):
             sum(if_else(x == data[i], 1, 0) for x in data))
 
     # find the highest frequency
-    highest_freq = sint(0)
+    highest_freq = sint(0) # sfix doesn't support if_else
     @for_range(n)
     def _(i):
         highest_freq.update(
@@ -218,7 +218,7 @@ def mode(data: list[sint]):
         ))
 
     # get the first occurrence of the highest frequency element in data
-    highest = sint(0)
+    highest = sfix(0)
     @for_range(n-1, -1, -1)
     def _(i):
         highest.update(if_else(freqs[i] == highest_freq,
@@ -229,11 +229,13 @@ def mode(data: list[sint]):
     return highest
 
 
-def variance(data: list[sint]):
+def variance(data: list[sfix]):
     return _variance(data, True)
 
 
-def linear_regression(xs: list[sint], ys: list[sint]):
+# using the formula described in:
+# https://en.wikipedia.org/wiki/Simple_linear_regression
+def linear_regression(xs: list[sfix], ys: list[sfix]):
     # zip(xs, ys) is a list of data points
 
     xs = Array.create_from(xs)
@@ -254,11 +256,10 @@ def linear_regression(xs: list[sint], ys: list[sint]):
     return res
 
 
-def harmonic_mean(data: list[sint]):
-    eff_size = sum(if_else(n != MAGIC_NUMBER, 1, 0) for n in data)
-    eff_inv_total = sum(if_else(n != MAGIC_NUMBER, 1/n, 0) for n in data)
-    eff_inv_mean = eff_inv_total / eff_size
-    result = 1 / eff_inv_mean
+def harmonic_mean(data: list[sfix]):
+    eff_size = sfix(sum(if_else(n != MAGIC_NUMBER, 1, 0) for n in data))
+    eff_inv_total = sfix(sum(if_else(n != MAGIC_NUMBER, 1/n, 0) for n in data))
+    result = eff_size / eff_inv_total
 
     # mpspdz doesn't raise division-by-zero error when data contains zeros
     # whereas statistics.harmonic_mean returns zero if data contain zeros
@@ -271,16 +272,16 @@ def harmonic_mean(data: list[sint]):
     return result
 
 
-def pvariance(data: list[sint]):
+def pvariance(data: list[sfix]):
     return _variance(data, False)
 
 
-def pstdev(data: list[sint]):
+def pstdev(data: list[sfix]):
     pvar = _variance(data, False)
-    return sqrt(sfix(pvar))
+    return sqrt(pvar)
 
 
-def stdev(data: list[sint]):
+def stdev(data: list[sfix]):
     var = _variance(data, True)
-    return sqrt(sfix(var))
+    return sqrt(var)
 

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -139,7 +139,7 @@ def covariance(data1: list[sint], data2: list[sint]):
     @for_range(n)
     def _(i):
         x.update(x+(data1[i]-mean1)*(data2[i]-mean2))
-    return x/count
+    return x/(count-1)
 
 
 def correlation(data1: list[sint], data2: list[sint]):

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -251,21 +251,20 @@ def linear_regression(xs: list[sint], ys: list[sint]):
     res.assign([slope, intercept])
     return res
 
-
-# LATER
-
 def harmonic_mean(data: list[sint]):
-    # TODO: implement harmonic_mean
+    eff_size = sum(if_else(n != MAGIC_NUMBER, 1, 0) for n in data)
+    eff_inv_total = sum(if_else(n != MAGIC_NUMBER, sfloat(1/n), 0) for n in data)
+    eff_inv_mean = eff_inv_total / eff_size
+    return 1 / eff_inv_mean
+
+
+def pvariance(data: list[sint]):
+    # TODO: implement pvariance
     raise NotImplementedError
 
 
 def pstdev(data: list[sint]):
     # TODO: implement pstdev
-    raise NotImplementedError
-
-
-def pvariance(data: list[sint]):
-    # TODO: implement pvariance
     raise NotImplementedError
 
 

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -14,6 +14,9 @@ MAGIC_NUMBER = 999
 # Ref: https://github.com/data61/MP-SPDZ/blob/e93190f3b72ee2d27837ca1ca6614df6b52ceef2/doc/machine-learning.rst?plain=1#L347-L353
 sfix.round_nearest = True
 
+f = 22 # length of decimal part
+k = 62 - f # whole bit length of fixed point. must be at least f+11
+sfix.set_precision(f, k)
 
 def read_data(party_index: int, num_columns: int, num_rows: int) -> Matrix:
     """
@@ -53,7 +56,11 @@ def _variance(data: list[sfix], use_bessels: bool) -> sfix:
 
     eff_data_sum = sfix(0)
     for n in data:
-        eff_data_sum += (n - mean) ** 2
+        eff_data_sum.update(eff_data_sum + (n - mean) ** 2)
+        #eff_data_sum += (n - mean) ** 2
+    # @for_range(len(data))
+    # def _(i):
+    #     eff_data_sum.update(eff_data_sum + (data[i] - mean) ** 2)
 
     if use_bessels:
         eff_size -= 1

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -232,23 +232,19 @@ def variance(data: list[sint]):
 
 
 def linear_regression(xs: list[sint], ys: list[sint]):
-    # each element in zip(xs, ys) is a data point, so
-    # xs and ys are assumed to have the same size
-
-    # calculate means of xs and ys
-    x_mean = mean(xs)
-    y_mean = mean(ys)
+    # zip(xs, ys) is a set of data points
 
     xs = Array.create_from(xs)
     ys = Array.create_from(ys)
 
-    # caclulate covariance of xs and ys
+    # calculate slope
     covar = covariance(xs, ys)
-
-    # calculate variance of xs
     var = variance(xs)
-
     slope = covar / var
+
+    # calculate intercept
+    x_mean = mean(xs)
+    y_mean = mean(ys)
     intercept = y_mean - slope * x_mean
 
     res = sfix.Array(2)

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -38,13 +38,13 @@ def print_data(data: Matrix):
             print_ln("data[{}][{}]: %s".format(i, j), data[i][j].reveal())
 
 
-def _mean(data: list[sint]) -> (sfloat, int):
+def _mean(data: list[sint]) -> (float, int):
     total = sum(if_else(i != MAGIC_NUMBER, i, 0) for i in data)
     count = sum(if_else(i != MAGIC_NUMBER, 1, 0) for i in data)
-    return sfloat(total / count), count
+    return total / count, count
 
 
-def _variance(data: list[sint], use_bessels: bool) -> sfloat:
+def _variance(data: list[sint], use_bessels: bool) -> float:
     # calculate mean of the data excluding magic numbers
     mean, eff_size = _mean(data)
 
@@ -58,7 +58,7 @@ def _variance(data: list[sint], use_bessels: bool) -> sfloat:
     if use_bessels:
         eff_size -= 1
 
-    return sfloat(eff_data_sum / eff_size)
+    return eff_data_sum / eff_size
 
 
 # Top 5 functions to implement

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -227,7 +227,7 @@ def variance(data: list[sint]):
     for n in data:
         var_sum += (n - mean) ** 2
 
-    var_size = len(data)
+    var_size = len(data) - 1
     return var_sum / var_size
 
 

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -256,7 +256,7 @@ def linear_regression(xs: list[sint], ys: list[sint]):
 
 def harmonic_mean(data: list[sint]):
     eff_size = sum(if_else(n != MAGIC_NUMBER, 1, 0) for n in data)
-    eff_inv_total = sum(if_else(n != MAGIC_NUMBER, sfloat(1/n), 0) for n in data)
+    eff_inv_total = sum(if_else(n != MAGIC_NUMBER, 1/n, 0) for n in data)
     eff_inv_mean = eff_inv_total / eff_size
     return 1 / eff_inv_mean
 

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -260,7 +260,9 @@ def harmonic_mean(data: list[sint]):
     eff_inv_mean = eff_inv_total / eff_size
     result = 1 / eff_inv_mean
 
-    # statistics.harmonic_mean returns zero if data contain zero
+    # mpspdz doesn't raise division-by-zero error when data contains zeros
+    # whereas statistics.harmonic_mean returns zero if data contain zeros
+    # this aligns the behavior with the python counterpart
     num_zeros = 0
     for x in data:
         num_zeros += (x == 0)

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -232,7 +232,7 @@ def variance(data: list[sint]):
 
 
 def linear_regression(xs: list[sint], ys: list[sint]):
-    # zip(xs, ys) is a set of data points
+    # zip(xs, ys) is a list of data points
 
     xs = Array.create_from(xs)
     ys = Array.create_from(ys)

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -220,15 +220,15 @@ def variance(data: list[sint]):
     eff_total = sum(if_else(n != MAGIC_NUMBER, n, 0) for n in data)
     mean = eff_total / eff_size
 
-    # replace magic number w/ mean to make 'n - mean' below zero
+    # replace magic number w/ mean to skip magic number in for loop below
     data = Array.create_from(if_else(n != MAGIC_NUMBER, n, mean) for n in data)
 
-    var_sum = sfloat(0)
+    eff_data_sum = sfloat(0)
     for n in data:
-        var_sum += (n - mean) ** 2
+        eff_data_sum += (n - mean) ** 2
 
-    var_size = len(data) - 1
-    return var_sum / var_size
+    # using eff_size-1 instead of eff_size based on Bessel's correction
+    return eff_data_sum / (eff_size - 1)
 
 
 def linear_regression(xs: list[sint], ys: list[sint]):

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -10,14 +10,6 @@ from Compiler.mpc_math import sqrt, exp2_fx, log2_fx
 
 MAGIC_NUMBER = 999
 
-# To enforce round to the nearest integer, instead of probabilistic truncation
-# Ref: https://github.com/data61/MP-SPDZ/blob/e93190f3b72ee2d27837ca1ca6614df6b52ceef2/doc/machine-learning.rst?plain=1#L347-L353
-sfix.round_nearest = True
-
-f = 22 # length of decimal part
-k = 62 - f # whole bit length of fixed point. must be at least f+11
-sfix.set_precision(f, k)
-
 def read_data(party_index: int, num_columns: int, num_rows: int) -> Matrix:
     """
     Read data from each party's input file to a Matrix in MP-SPDZ circuit.

--- a/mpcstats_lib.py
+++ b/mpcstats_lib.py
@@ -139,7 +139,7 @@ def covariance(data1: list[sint], data2: list[sint]):
     @for_range(n)
     def _(i):
         x.update(x+(data1[i]-mean1)*(data2[i]-mean2))
-    return x/(count-1)
+    return x/count
 
 
 def correlation(data1: list[sint], data2: list[sint]):
@@ -213,6 +213,49 @@ def mode(data: list[sint]):
 
     return highest
 
+
+def variance(data: list[sint]):
+    # calculate mean of the data excluding magic numbers
+    eff_size = sum(if_else(n != MAGIC_NUMBER, 1, 0) for n in data)
+    eff_total = sum(if_else(n != MAGIC_NUMBER, n, 0) for n in data)
+    mean = eff_total / eff_size
+
+    # replace magic number w/ mean to make 'n - mean' below zero
+    data = Array.create_from(if_else(n != MAGIC_NUMBER, n, mean) for n in data)
+
+    var_sum = sfloat(0)
+    for n in data:
+        var_sum += (n - mean) ** 2
+
+    var_size = len(data)
+    return var_sum / var_size
+
+
+def linear_regression(xs: list[sint], ys: list[sint]):
+    # each element in zip(xs, ys) is a data point, so
+    # xs and ys are assumed to have the same size
+
+    # calculate means of xs and ys
+    x_mean = mean(xs)
+    y_mean = mean(ys)
+
+    xs = Array.create_from(xs)
+    ys = Array.create_from(ys)
+
+    # caclulate covariance of xs and ys
+    covar = covariance(xs, ys)
+
+    # calculate variance of xs
+    var = variance(xs)
+
+    slope = covar / var
+    intercept = y_mean - slope * x_mean
+
+    res = sfix.Array(2)
+    res.assign([slope, intercept])
+    return res
+
+
 # LATER
 
 def harmonic_mean(data: list[sint]):
@@ -234,12 +277,3 @@ def stdev(data: list[sint]):
     # TODO: implement stdev
     raise NotImplementedError
 
-
-def variance(data: list[sint]):
-    # TODO: implement variance
-    raise NotImplementedError
-
-
-def linear_regression(data1: list[sint], data2: list[sint]):
-    # TODO: implement linear_regression
-    raise NotImplementedError

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -204,9 +204,9 @@ def execute_stat_func_test(
         pystats_res = vector_res_parser(pystats_res)
 
         for mp, py in zip(mpspdz_res, pystats_res):
-            print(f'mp={mp}, py={py}')
             assert abs(float(mp) - py) < tolerance
     else:
+        print(f'mp={float(mpspdz_res)}, py={float(pystats_res)}')
         assert abs(float(mpspdz_res) - pystats_res) < tolerance
 
 def execute_elem_filter_test(

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -173,8 +173,11 @@ def assert_mp_py_diff(mp, py, tolerance):
     py = float(py)
 
     if py == 0:
-        print(f'mp={mp}, py={py}, diff=?')
-        assert False
+        if mp == 0:
+            print(f'mp={mp}, py={py}, diff=0')
+        else:
+            print(f'mp={mp}, py={py}, diff=?')
+            assert False
     else:
         diff = (py - mp) / py
         print(f'mp={mp}, py={py}, diff={diff*100:.5f}%')

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -168,6 +168,18 @@ def extract_result_from_mpspdz_stdout(stdout):
 
     raise Exception('Result missing in MP-SPDZ output')
 
+def assert_mp_py_diff(mp, py, tolerance):
+    mp = float(mp)
+    py = float(py)
+
+    if py == 0:
+        print(f'mp={mp}, py={py}, diff=?')
+        assert False
+    else:
+        diff = (py - mp) / py
+        print(f'mp={mp}, py={py}, diff={diff*100:.5f}%')
+        assert abs(diff) < tolerance
+
 def execute_stat_func_test(
     mpcstats_func,
     pystats_func,
@@ -213,17 +225,9 @@ def execute_stat_func_test(
         pystats_res = vector_res_parser(pystats_res)
 
         for mp, py in zip(mpspdz_res, pystats_res):
-            mp = float(mp)
-            py = float(py)
-            diff = ((py - mp) / py)
-            print(f'mp={mp}, py={py}, diff={diff*100:.5f}%')
-            assert abs(diff) < tolerance
+            assert_mp_py_diff(mp, py, tolerance)
     else:
-        mp = float(mpspdz_res)
-        py = float(pystats_res)
-        diff = ((py - mp) / py)
-        print(f'mp={mp}, py={py}, diff={diff*100:.5f}%')
-        assert abs(diff) < tolerance
+        assert_mp_py_diff(mpspdz_res, pystats_res, tolerance)
 
 def execute_elem_filter_test(
     func,

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -138,13 +138,16 @@ def run_pystats_func(
 ): 
     party_ids = list(range(num_params))
     col1 = player_data[party_ids[0]][selected_col]
+    print(f'col1: {col1}')
     col1 = exclude_magic_number(col1)
+    print(f'col1 excl M: {col1}')
 
     if num_params == 1:
         return func(col1) 
 
     elif num_params == 2:
         col2 = player_data[party_ids[1]][selected_col]
+        print(f'col2: {col2}')
         col2 = exclude_magic_number(col2)
         return func(col1, col2) 
     else:
@@ -190,6 +193,7 @@ def execute_stat_func_test(
         mpc_script,
         'testmpc',
     )
+    print(f'stdout:{mpspdz_stdout}')
     mpspdz_res = extract_result_from_mpspdz_stdout(mpspdz_stdout)
 
     pystats_res = run_pystats_func(

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -167,6 +167,7 @@ def execute_stat_func_test(
     player_data,
     selected_col,
     tolerance,
+    vector_res_parser = None, # None or callable 
 ):
     computation = gen_stat_func_comp(
         player_data,
@@ -197,8 +198,16 @@ def execute_stat_func_test(
         selected_col,
         pystats_func,
     )
-    print(f'---> mp: {mpspdz_res}, py: {pystats_res}')
-    assert abs(float(mpspdz_res) - pystats_res) < tolerance
+
+    if callable(vector_res_parser):
+        mpspdz_res = ast.literal_eval(mpspdz_res) 
+        pystats_res = vector_res_parser(pystats_res)
+
+        for mp, py in zip(mpspdz_res, pystats_res):
+            print(f'mp={mp}, py={py}')
+            assert abs(float(mp) - py) < tolerance
+    else:
+        assert abs(float(mpspdz_res) - pystats_res) < tolerance
 
 def execute_elem_filter_test(
     func,

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -213,10 +213,17 @@ def execute_stat_func_test(
         pystats_res = vector_res_parser(pystats_res)
 
         for mp, py in zip(mpspdz_res, pystats_res):
-            assert abs(float(mp) - py) < tolerance
+            mp = float(mp)
+            py = float(py)
+            diff = ((py - mp) / py)
+            print(f'mp={mp}, py={py}, diff={diff*100:.5f}%')
+            assert abs(diff) < tolerance
     else:
-        print(f'mp={float(mpspdz_res)}, py={float(pystats_res)}')
-        assert abs(float(mpspdz_res) - pystats_res) < tolerance
+        mp = float(mpspdz_res)
+        py = float(pystats_res)
+        diff = ((py - mp) / py)
+        print(f'mp={mp}, py={py}, diff={diff*100:.5f}%')
+        assert abs(diff) < tolerance
 
 def execute_elem_filter_test(
     func,

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -153,6 +153,7 @@ def run_pystats_func(
         col2 = player_data[party_ids[1]][selected_col]
         print(f'col2: {col2}')
         col2 = exclude_magic_number(col2)
+        print(f'col2 excl M: {col2}')
         return func(col1, col2) 
     else:
         raise Exception(f'# of func params is expected to be 1 or 2, but got {num_params}')

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -74,19 +74,21 @@ def create_player_data_files(data_dir, player_data):
                 f.write(' '.join(map(str, col)))
                 f.write('\n')
 
+def gen_magic_num_indices(rows, magic_num_rate):
+    num_magic_nums = int(rows * magic_num_rate)
+    return random.sample(range(rows), num_magic_nums)
+
 def generate_col(
     rows,
-    magic_num_rate,
+    magic_num_indices,
     range_beg,
     range_end,
 ):
     # generate column with random numbers
     col = [random.randrange(range_beg, range_end) for _ in range(rows)]
 
-    # replace numbers with magic numbers at a given rate
-    num_magic_nums = int(rows * magic_num_rate)
-    magic_num_idxs = random.sample(range(rows), num_magic_nums)
-    for idx in magic_num_idxs:
+    # replace numbers by magic numbers
+    for idx in magic_num_indices:
         col[idx] = MAGIC_NUMBER
 
     return col
@@ -99,11 +101,13 @@ def gen_player_data(
     range_end,
     magic_num_rate,
 ):
+    magic_num_indices = gen_magic_num_indices(rows, magic_num_rate)
+
     res = []
     for _ in range(num_parties):
         mat = []
         for _ in range(cols):
-            col = generate_col(rows, magic_num_rate, range_beg, range_end)
+            col = generate_col(rows, magic_num_indices, range_beg, range_end)
             mat.append(col)
         res.append(mat)
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -381,9 +381,22 @@ def test_linear_regression_success():
         vector_res_parser = vector_res_parser,
     )
 
-def test_harmonic_mean_success():
+def test_harmonic_mean_non_zero_input_success():
     # python harmonic_mean doesn't support negative values
-    player_data = gen_player_data(30, 2, 2, 0, 100, 0.5)
+    player_data = gen_player_data(30, 2, 2, 1, 100, 0.5)
+    execute_stat_func_test(
+        mpcstats_lib.harmonic_mean,
+        statistics.harmonic_mean,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        tolerance = 0.005,
+    )
+
+def test_harmonic_mean_input_contains_0_success():
+    # python harmonic_mean doesn't support negative values
+    player_data = gen_player_data(30, 2, 2, 1, 100, 0.5)
+    player_data[0][1][0] = 0
     execute_stat_func_test(
         mpcstats_lib.harmonic_mean,
         statistics.harmonic_mean,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -390,7 +390,7 @@ def test_harmonic_mean_success():
         num_params = 1,
         player_data = player_data,
         selected_col = 1,
-        tolerance = TOLERANCE_SMALL,
+        tolerance = 0.01,
     )
 
 def test_pvariance_success():

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -367,3 +367,15 @@ def test_linear_regression_success():
         vector_res_parser = vector_res_parser,
     )
 
+def test_harmonic_mean_success():
+    # python harmonic_mean doesn't support negative values
+    player_data = gen_player_data(30, 2, 2, 0, 100, 0.5)
+    execute_stat_func_test(
+        mpcstats_lib.harmonic_mean,
+        statistics.harmonic_mean,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        tolerance = 0.01,
+    )
+

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -33,11 +33,12 @@ def test_correlation_success():
     )
 
 def test_covariance_success():
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
     execute_stat_func_test(
         mpcstats_lib.covariance,
         statistics.covariance,
         num_params = 2,
-        player_data = player_data_4x2_2_party,
+        player_data = player_data,
         selected_col = 1,
         tolerance = 0.01,
     )

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -340,6 +340,17 @@ def test_mode_fail_all_magic_numbers():
         tolerance = 0.01,
     )
 
+def test_variance_success():
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0)
+    execute_stat_func_test(
+        mpcstats_lib.variance,
+        statistics.variance,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        tolerance = 0.01,
+    )
+
 def test_linear_regression_success():
     def vector_res_parser(x):
         return [x.slope, x.intercept]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -341,7 +341,7 @@ def test_mode_fail_all_magic_numbers():
     )
 
 def test_variance_success():
-    player_data = gen_player_data(30, 2, 2, -100, 100, 0)
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
     execute_stat_func_test(
         mpcstats_lib.variance,
         statistics.variance,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -390,7 +390,7 @@ def test_harmonic_mean_success():
         num_params = 1,
         player_data = player_data,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
     )
 
 def test_pvariance_success():
@@ -412,7 +412,7 @@ def test_pstdev_success():
         num_params = 1,
         player_data = player_data,
         selected_col = 1,
-        # due to use of sqrt, the result can differ up to 5%
+        # due to use of sfix and sqrt, the result can differ up to 5%
         tolerance = 0.05,
     )
 
@@ -424,7 +424,7 @@ def test_stdev_success():
         num_params = 1,
         player_data = player_data,
         selected_col = 1,
-        # due to use of sqrt, the result can differ up to 5%
+        # due to use of sfix and sqrt, the result can differ up to 5%
         tolerance = 0.05,
     )
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -355,7 +355,7 @@ def test_linear_regression_success():
     def vector_res_parser(x):
         return [x.slope, x.intercept]
 
-    player_data = gen_player_data(30, 2, 2, -100, 100, 0)
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
     execute_stat_func_test(
         mpcstats_lib.linear_regression,
         statistics.linear_regression,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,7 +1,7 @@
 import pytest, statistics
 
 import mpcstats_lib
-from .lib import execute_elem_filter_test, execute_join_test, execute_stat_func_test, gen_player_data_for_1_param_func
+from .lib import execute_elem_filter_test, execute_join_test, execute_stat_func_test, gen_player_data_for_1_param_func, gen_player_data
 
 player_data_4x2_2_party = [
     # party 0
@@ -329,7 +329,6 @@ def test_mode_fail_empty_input():
         tolerance = 0.01,
     )
 
-
 @pytest.mark.xfail(raises=statistics.StatisticsError, reason='no mode for empty data')
 def test_mode_fail_all_magic_numbers():
     execute_stat_func_test(
@@ -340,3 +339,19 @@ def test_mode_fail_all_magic_numbers():
         selected_col = 1,
         tolerance = 0.01,
     )
+
+def test_linear_regression_success():
+    def vector_res_parser(x):
+        return [x.slope, x.intercept]
+
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0)
+    execute_stat_func_test(
+        mpcstats_lib.linear_regression,
+        statistics.linear_regression,
+        num_params = 2,
+        player_data = player_data,
+        selected_col = 1,
+        tolerance = 0.01,
+        vector_res_parser = vector_res_parser,
+    )
+

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -18,6 +18,9 @@ player_data_4x2_2_party = [
 
 M = mpcstats_lib.MAGIC_NUMBER
 
+TOLERANCE_SMALL = 0.0001  # 0.01%
+
+
 def pd1(col):
     return gen_player_data_for_1_param_func(col, 2, 1)
 
@@ -29,7 +32,7 @@ def test_correlation_success():
         num_params = 2,
         player_data = player_data_4x2_2_party,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = 0.02,
     )
 
 def test_covariance_success():
@@ -40,7 +43,7 @@ def test_covariance_success():
         num_params = 2,
         player_data = player_data,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
     )
 
 def test_geometric_mean_success():
@@ -50,7 +53,7 @@ def test_geometric_mean_success():
         num_params = 1,
         player_data = player_data_4x2_2_party,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
     )
 
 def test_median_success():
@@ -60,7 +63,7 @@ def test_median_success():
         num_params = 1,
         player_data = player_data_4x2_2_party,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
     )
 
 def test_where_success():
@@ -316,7 +319,7 @@ def test_mode_success():
             num_params = 1,
             player_data = tc,
             selected_col = 1,
-            tolerance = 0.01,
+            tolerance = TOLERANCE_SMALL,
         )
 
 @pytest.mark.xfail(raises=IndexError, reason='list index out of range')
@@ -327,7 +330,7 @@ def test_mode_fail_empty_input():
         num_params = 1,
         player_data = pd1([]),
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
     )
 
 @pytest.mark.xfail(raises=statistics.StatisticsError, reason='no mode for empty data')
@@ -338,7 +341,18 @@ def test_mode_fail_all_magic_numbers():
         num_params = 1,
         player_data = pd1([M, M, M, M]),
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
+    )
+
+def test_mean_success():
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
+    execute_stat_func_test(
+        mpcstats_lib.mean,
+        statistics.mean,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        tolerance = TOLERANCE_SMALL,
     )
 
 def test_variance_success():
@@ -349,7 +363,7 @@ def test_variance_success():
         num_params = 1,
         player_data = player_data,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
     )
 
 def test_linear_regression_success():
@@ -363,7 +377,7 @@ def test_linear_regression_success():
         num_params = 2,
         player_data = player_data,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
         vector_res_parser = vector_res_parser,
     )
 
@@ -376,6 +390,41 @@ def test_harmonic_mean_success():
         num_params = 1,
         player_data = player_data,
         selected_col = 1,
-        tolerance = 0.01,
+        tolerance = TOLERANCE_SMALL,
+    )
+
+def test_pvariance_success():
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
+    execute_stat_func_test(
+        mpcstats_lib.pvariance,
+        statistics.pvariance,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        tolerance = TOLERANCE_SMALL,
+    )
+
+def test_pstdev_success():
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
+    execute_stat_func_test(
+        mpcstats_lib.pstdev,
+        statistics.pstdev,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        # due to use of sqrt, the result can differ up to 5%
+        tolerance = 0.05,
+    )
+
+def test_stdev_success():
+    player_data = gen_player_data(30, 2, 2, -100, 100, 0.5)
+    execute_stat_func_test(
+        mpcstats_lib.stdev,
+        statistics.stdev,
+        num_params = 1,
+        player_data = player_data,
+        selected_col = 1,
+        # due to use of sqrt, the result can differ up to 5%
+        tolerance = 0.05,
     )
 


### PR DESCRIPTION
- Add following functions:
  - linear_regression
  - variance
  - stdev
  - pvariance
  - pstdev
  - harmonic_mean
- Factor out mean calculation to _mean function
- Factor out variance calculation to _variance function
- Add mean test
- Use randomly generated input in covariance test
- Change the test library to:
  - use the same magic number indices for all player data columns in tests
  - add support for vector output
  - provide input data used in the output
  - use tolerance in percent
- Replace the use of `sint` with `sfix` in all possible places in `mpcstats_lib.py`
- Set higher precision than the default to `sfix`
- Make MP-SPDZ configuraiton configurable